### PR TITLE
Disable package hashing for faster performance of large packages

### DIFF
--- a/source/NuGet.Lucene.Web/INuGetWebApiSettings.cs
+++ b/source/NuGet.Lucene.Web/INuGetWebApiSettings.cs
@@ -40,6 +40,7 @@ namespace NuGet.Lucene.Web
         bool SynchronizeOnStart { get; }
         bool EnablePackageFileWatcher { get; }
         bool KeepSourcesCompressed { get; }
+        bool DisablePackageHash { get; }
         PackageOverwriteMode PackageOverwriteMode { get; }
         int LuceneMergeFactor { get; }
     }

--- a/source/NuGet.Lucene.Web/NuGetWebApiModule.cs
+++ b/source/NuGet.Lucene.Web/NuGetWebApiModule.cs
@@ -75,7 +75,8 @@ namespace NuGet.Lucene.Web
                 LuceneIndexPath = settings.LucenePackagesIndexPath,
                 PackagePath = settings.PackagesPath,
                 PackageOverwriteMode = settings.PackageOverwriteMode,
-                LuceneMergeFactor = settings.LuceneMergeFactor
+                LuceneMergeFactor = settings.LuceneMergeFactor,
+                DisablePackageHash = settings.DisablePackageHash
             };
 
             cfg.Initialize();

--- a/source/NuGet.Lucene.Web/NuGetWebApiSettings.cs
+++ b/source/NuGet.Lucene.Web/NuGetWebApiSettings.cs
@@ -128,6 +128,14 @@ namespace NuGet.Lucene.Web
             }
         }
 
+        public bool DisablePackageHash
+        {
+            get
+            {
+                return GetFlagFromAppSetting("disablePackageHash", false);
+            }
+        }
+
         public bool SynchronizeOnStart
         {
             get

--- a/source/NuGet.Lucene/LucenePackageRepository.cs
+++ b/source/NuGet.Lucene/LucenePackageRepository.cs
@@ -37,6 +37,8 @@ namespace NuGet.Lucene
 
         public string HashAlgorithmName { get; set; }
 
+        public bool DisablePackageHash { get; set; }
+
         public string LucenePackageSource { get; set; }
 
         public PackageOverwriteMode PackageOverwriteMode { get; set; }
@@ -526,7 +528,14 @@ namespace NuGet.Lucene
 
         protected override IPackage OpenPackage(string path)
         {
-            return FastZipPackage.Open(path, HashProvider);
+            if (DisablePackageHash)
+            {
+                return FastZipPackage.Open(path, new byte[0]);
+            }
+            else
+            {
+                return FastZipPackage.Open(path, HashProvider);
+            }
         }
 
         public LucenePackage Convert(IPackage package)

--- a/source/NuGet.Lucene/LuceneRepositoryConfigurator.cs
+++ b/source/NuGet.Lucene/LuceneRepositoryConfigurator.cs
@@ -48,6 +48,11 @@ namespace NuGet.Lucene
         public string PackageHashAlgorithm { get; set; }
 
         /// <summary>
+        /// Disable package hashing
+        /// </summary>
+        public bool DisablePackageHash { get; set; }
+
+        /// <summary>
         /// Holds a reference to the configured package repository
         /// after <see cref="Initialize"/> has been invoked.
         /// </summary>
@@ -117,6 +122,7 @@ namespace NuGet.Lucene
                 {
                     HashProvider = hashProvider,
                     HashAlgorithmName = PackageHashAlgorithm,
+                    DisablePackageHash = DisablePackageHash,
                     PathResolver = packagePathResolver,
                     Indexer = PackageIndexer,
                     LuceneDataProvider = Provider,


### PR DESCRIPTION
Hi Chris,

For our admittedly rather huge packages that we have, disabling hashing of the packages has a big improvement:

	Disabled
		CPU Time		01:46
		Elapsed			02:58
		
	Enabled
		CPU Time		03:12
		Elapsed			04:09


Would there be any negative effect of us disabling this? It's purely for an internal nuget feed so I don't believe we'd require the security of hashing the packages

Thanks,
Richard
