### PR TITLE
Updated UserStore to implement IDisposable so the Lucene provider is disposed properly

### DIFF
--- a/source/NuGet.Lucene.Web.Tests/Controllers/UsersControllerTests.cs
+++ b/source/NuGet.Lucene.Web.Tests/Controllers/UsersControllerTests.cs
@@ -16,7 +16,7 @@ namespace NuGet.Lucene.Web.Tests.Controllers
     [TestFixture]
     public class UsersControllerTests : ApiControllerTests<UsersController>
     {
-        private UserStore store;
+        private IUserStore store;
 
         protected override UsersController CreateController()
         {

--- a/source/NuGet.Lucene.Web.Tests/Middleware/LocalRequestAuthenticationMiddlewareTest.cs
+++ b/source/NuGet.Lucene.Web.Tests/Middleware/LocalRequestAuthenticationMiddlewareTest.cs
@@ -16,7 +16,7 @@ namespace NuGet.Lucene.Web.Tests.Middleware
         [SetUp]
         public void SetUp()
         {
-            var store = new UserStore(new LuceneDataProvider(new RAMDirectory(), Version.LUCENE_30));
+            IUserStore store = new UserStore(new LuceneDataProvider(new RAMDirectory(), Version.LUCENE_30));
             middleware = new LocalRequestAuthenticationMiddleware(next) { Store = store };
         }
 

--- a/source/NuGet.Lucene.Web.Tests/Middleware/RoleMappingAuthenticationMiddlewareTests.cs
+++ b/source/NuGet.Lucene.Web.Tests/Middleware/RoleMappingAuthenticationMiddlewareTests.cs
@@ -16,7 +16,7 @@ namespace NuGet.Lucene.Web.Tests.Middleware
     public class RoleMappingAuthenticationMiddlewareTests : AuthenticationMiddlewareTestBase
     {
         private RoleMappingAuthenticationMiddleware middleware;
-        private UserStore store;
+        private IUserStore store;
         private NameValueCollection mappings;
         private ApiUserPrincipal domainAdminUser;
 

--- a/source/NuGet.Lucene.Web.Tests/NuGetWebApiModuleTests.cs
+++ b/source/NuGet.Lucene.Web.Tests/NuGetWebApiModuleTests.cs
@@ -25,6 +25,16 @@ namespace NuGet.Lucene.Web.Tests
         }
 
         [Test]
+        public void DisposeUserStore()
+        {
+            BuildContainer();
+
+            container.Dispose();
+
+            module.UserStore.Verify(c => c.Dispose(), Times.Once);
+        }
+
+        [Test]
         public void RegistersRepository()
         {
             BuildContainer();
@@ -47,7 +57,7 @@ namespace NuGet.Lucene.Web.Tests
         [Test]
         [TestCase(typeof(IMirroringPackageRepository))]
         [TestCase(typeof(NuGetWebApiRouteMapper))]
-        [TestCase(typeof(UserStore))]
+        [TestCase(typeof(IUserStore))]
         [TestCase(typeof(ISymbolSource))]
         [TestCase(typeof(SymbolTools))]
         public void RegistersType(Type type)
@@ -69,6 +79,7 @@ namespace NuGet.Lucene.Web.Tests
         {
             public Mock<ILuceneRepositoryConfigurator> Configurator { get; private set; }
             public Mock<ILucenePackageRepository> Repository { get; private set; }
+            public Mock<IUserStore> UserStore { get; private set; }
 
             protected override ILuceneRepositoryConfigurator InitializeRepositoryConfigurator(INuGetWebApiSettings settings)
             {
@@ -78,9 +89,10 @@ namespace NuGet.Lucene.Web.Tests
                 return Configurator.Object;
             }
 
-            protected override UserStore InitializeUserStore(INuGetWebApiSettings settings)
+            protected override IUserStore InitializeUserStore(INuGetWebApiSettings settings)
             {
-                return new UserStore(null);
+                UserStore = new Mock<IUserStore>();
+                return UserStore.Object;
             }
         }
     }

--- a/source/NuGet.Lucene.Web.Tests/UserStoreTests.cs
+++ b/source/NuGet.Lucene.Web.Tests/UserStoreTests.cs
@@ -11,7 +11,7 @@ namespace NuGet.Lucene.Web.Tests
     public class UserStoreTests
     {
         private LuceneDataProvider provider;
-        private UserStore store;
+        private IUserStore store;
 
         [SetUp]
         public void SetUp()

--- a/source/NuGet.Lucene.Web/Authentication/LuceneApiKeyAuthentication.cs
+++ b/source/NuGet.Lucene.Web/Authentication/LuceneApiKeyAuthentication.cs
@@ -9,7 +9,7 @@ namespace NuGet.Lucene.Web.Authentication
     {
         public const string ApiKeyHeader = "X-NuGet-ApiKey";
 
-        public UserStore Store { get; set; }
+        public IUserStore Store { get; set; }
 
         public IPrincipal AuthenticateRequest(IOwinRequest request)
         {

--- a/source/NuGet.Lucene.Web/Controllers/UsersController.cs
+++ b/source/NuGet.Lucene.Web/Controllers/UsersController.cs
@@ -21,7 +21,7 @@ namespace NuGet.Lucene.Web.Controllers
     /// </summary>
     public class UsersController : ApiControllerBase
     {
-        public UserStore Store { get; set; }
+        public IUserStore Store { get; set; }
 
         /// <summary>
         /// Retrieves a list of all users.

--- a/source/NuGet.Lucene.Web/IUserStore.cs
+++ b/source/NuGet.Lucene.Web/IUserStore.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NuGet.Lucene.Web.Authentication;
+
+namespace NuGet.Lucene.Web
+{
+    public interface IUserStore : IDisposable
+    {
+        /// <summary>
+        /// Gets or sets the string value of the local administrator username.
+        /// </summary>
+        string LocalAdministratorUsername { get; }
+
+        /// <summary>
+        /// Gets or sets the boolean value that indicates if requests on a 
+        /// local address should automatically be granted administrative roles.
+        /// </summary>
+        bool HandleLocalRequestsAsAdmin { get; set; }
+
+        /// <summary>
+        /// Gets or sets the string value of the local administrators api key.
+        /// </summary>
+        string LocalAdministratorApiKey { get; set; }
+
+        /// <summary>
+        /// Gets the boolean value that indicates if the local administrator 
+        /// user is enabled.
+        /// </summary>
+        bool IsLocalAdministratorEnabled { get; }
+
+        /// <summary>
+        /// Provides access to users to facilitate iteration over the collection.
+        /// </summary>
+        IEnumerable<ApiUser> All { get; }
+
+        /// <summary>
+        /// Configures the user store.
+        /// </summary>
+        void Initialize();
+
+        /// <summary>
+        /// Gets a user by searching on username.
+        /// </summary>
+        ApiUser FindByUsername(string username);
+
+        /// <summary>
+        /// Gets a user by searching on api key.
+        /// </summary>
+        ApiUser FindByKey(string key);
+
+        /// <summary>
+        /// Adds a user to the store.
+        /// </summary>
+        void Add(ApiUser user);
+
+        /// <summary>
+        /// Adds a user to the store specifying the update mode.
+        /// </summary>
+        void Add(ApiUser user, UserUpdateMode mode);
+
+        /// <summary>
+        /// Updates a user by searching on username.
+        /// </summary>
+        void Update(string username, string newUsername, string key, string[] roles, UserUpdateMode mode);
+
+        /// <summary>
+        /// Deletes a user by searching on username.
+        /// </summary>
+        void Delete(string username);
+
+        /// <summary>
+        /// Deletes all users in the store.
+        /// </summary>
+        void DeleteAll();
+
+        /// <summary>
+        /// Changes the requested users api key.
+        /// 
+        /// The string returned is the value of the new api key.
+        /// </summary>
+        string ChangeApiKey(string username, string newKey);
+    }
+}

--- a/source/NuGet.Lucene.Web/Middleware/LocalRequestAuthenticationMiddleware.cs
+++ b/source/NuGet.Lucene.Web/Middleware/LocalRequestAuthenticationMiddleware.cs
@@ -13,7 +13,7 @@ namespace NuGet.Lucene.Web.Middleware
     /// </summary>
     public class LocalRequestAuthenticationMiddleware : AuthenticationMiddlewareBase
     {
-        public UserStore Store { get; set; }
+        public IUserStore Store { get; set; }
 
         public LocalRequestAuthenticationMiddleware(OwinMiddleware next)
             : base(next)
@@ -27,7 +27,7 @@ namespace NuGet.Lucene.Web.Middleware
 
         class LocalRequestAuthenticationHandler : UserStoreAuthenticationHandler
         {
-            public LocalRequestAuthenticationHandler(UserStore store)
+            public LocalRequestAuthenticationHandler(IUserStore store)
                 : base(store)
             {
             }

--- a/source/NuGet.Lucene.Web/Middleware/RoleMappingAuthenticationMiddleware.cs
+++ b/source/NuGet.Lucene.Web/Middleware/RoleMappingAuthenticationMiddleware.cs
@@ -11,7 +11,7 @@ namespace NuGet.Lucene.Web.Middleware
 {
     public class RoleMappingAuthenticationMiddleware : AuthenticationMiddlewareBase
     {
-        public UserStore Store { get; set; }
+        public IUserStore Store { get; set; }
         public INuGetWebApiSettings Settings { get; set; }
 
         public RoleMappingAuthenticationMiddleware(OwinMiddleware next)
@@ -29,7 +29,7 @@ namespace NuGet.Lucene.Web.Middleware
             private static readonly string[] Empty = new String[0];
             private readonly NameValueCollection roleMappings;
 
-            public RoleMappingAuthenticationHandler(UserStore store, NameValueCollection roleMappings)
+            public RoleMappingAuthenticationHandler(IUserStore store, NameValueCollection roleMappings)
                 : base(store)
             {
                 this.roleMappings = roleMappings;

--- a/source/NuGet.Lucene.Web/Middleware/UserStoreAuthenticationHandler.cs
+++ b/source/NuGet.Lucene.Web/Middleware/UserStoreAuthenticationHandler.cs
@@ -2,9 +2,9 @@ namespace NuGet.Lucene.Web.Middleware
 {
     public abstract class UserStoreAuthenticationHandler : AuthenticationHandlerBase
     {
-        protected readonly UserStore store;
+        protected readonly IUserStore store;
 
-        protected UserStoreAuthenticationHandler(UserStore store)
+        protected UserStoreAuthenticationHandler(IUserStore store)
         {
             this.store = store;
         }

--- a/source/NuGet.Lucene.Web/NuGet.Lucene.Web.csproj
+++ b/source/NuGet.Lucene.Web/NuGet.Lucene.Web.csproj
@@ -189,6 +189,7 @@
     <Compile Include="Formatters\PackageHtmlSerializer.cs" />
     <Compile Include="Formatters\PackageSummaryListSerializer.cs" />
     <Compile Include="INuGetWebApiSettings.cs" />
+    <Compile Include="IUserStore.cs" />
     <Compile Include="Models\DelegatingPackageRepository.cs" />
     <Compile Include="Models\KeyChangeRequest.cs" />
     <Compile Include="Models\MirroringPackageRepository.cs" />

--- a/source/NuGet.Lucene.Web/NuGetWebApiModule.cs
+++ b/source/NuGet.Lucene.Web/NuGetWebApiModule.cs
@@ -106,7 +106,7 @@ namespace NuGet.Lucene.Web
             }
         }
 
-        protected virtual UserStore InitializeUserStore(INuGetWebApiSettings settings)
+        protected virtual IUserStore InitializeUserStore(INuGetWebApiSettings settings)
         {
             var usersDataProvider = InitializeUsersDataProvider(settings);
             var userStore = new UserStore(usersDataProvider)

--- a/source/NuGet.Lucene.Web/UserStore.cs
+++ b/source/NuGet.Lucene.Web/UserStore.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Common.Logging;
 using Lucene.Net.Linq;
 using NuGet.Lucene.Web.Authentication;
 
@@ -18,7 +19,7 @@ namespace NuGet.Lucene.Web
 
     public enum UserUpdateMode { Overwrite, NoClobber }
 
-    public class UserStore
+    public class UserStore : IDisposable
     {
         private readonly LuceneDataProvider provider;
 
@@ -251,6 +252,13 @@ namespace NuGet.Lucene.Web
         protected virtual bool IsApiKeyUnmodifiable(string username)
         {
             return IsProtectedAccount(username) && !string.IsNullOrWhiteSpace(LocalAdministratorApiKey);
+        }
+
+        public void Dispose()
+        {
+            LogManager.GetCurrentClassLogger().Info("Stopping UserStore indexing services.");
+
+            provider.Dispose();
         }
     }
 }

--- a/source/NuGet.Lucene.Web/UserStore.cs
+++ b/source/NuGet.Lucene.Web/UserStore.cs
@@ -19,7 +19,7 @@ namespace NuGet.Lucene.Web
 
     public enum UserUpdateMode { Overwrite, NoClobber }
 
-    public class UserStore : IDisposable
+    public class UserStore : IUserStore
     {
         private readonly LuceneDataProvider provider;
 


### PR DESCRIPTION
I'm using NuGet.Lucene.Web to allow a feed to be started/stopped on demand. I can start and stop the feed once, but if I try to start it again I get a LockObtainFailedException.

![lockerror](https://cloud.githubusercontent.com/assets/7475696/7241261/87494ecc-e7af-11e4-8859-42c1e8ccc8c6.PNG)

Code to reproduce:

```
           Startup startup = null;

            var webApp = WebApp.Start("localhost:99991", app =>
            {
                startup = new Startup();
                startup.Configuration(app);
            });

            webApp.Dispose();
            startup.WaitForShutdown(TimeSpan.FromSeconds(30));

            webApp = WebApp.Start("localhost:99991", app => //This is the line which throws the exception above
            {
                startup = new Startup();
                startup.Configuration(app);
            });
```

After looking at the ```LuceneRepositoryConfigurator``` class it implements IDisposable which then disposes the Lucene provider. Looking at the ```UserStore``` class it also uses a Lucene provider but it does not implement IDisposable (or dispose of the provider anywhere else). 

This change implements IDisposable in ```UserStore``` and disposes of the provider. The UserStore is already registered with the Autofac.ContainerBuilder which will now dispose it during shutdown in the ```Startup.cs```.