### PR TITLE
Fix for bug #42.

### DIFF
--- a/source/NuGet.Lucene/LucenePackageRepository.cs
+++ b/source/NuGet.Lucene/LucenePackageRepository.cs
@@ -208,7 +208,7 @@ namespace NuGet.Lucene
 
         protected virtual System.Net.Http.HttpClient CreateHttpClient()
         {
-            return new System.Net.Http.HttpClient();
+            return new System.Net.Http.HttpClient(new System.Net.Http.HttpClientHandler() { UseDefaultCredentials = true });
         }
 
         protected virtual Stream OpenFileWriteStream(string path)


### PR DESCRIPTION
Sorry if I messed this up somehow.  I'm new to Git and this is my first pull request.  At any rate, HttpClient has a default value of "false" for UseDefaultCredentials while HttpWebRequest defaults to "true".  This creates an odd situation where half of the network traffic responds to 401 challenges with the app pool identity except where HttpClient is used explicitly.  I was just trying to make this work a bit more consistently.  You may consider looking at using the HttpClient that Nuget.Core guys have built-in for a longer term solution.