### PR TITLE
Added missing newline in the source mapping index

### DIFF
--- a/source/NuGet.Lucene.Web/Symbols/SymbolSourceMapper.cs
+++ b/source/NuGet.Lucene.Web/Symbols/SymbolSourceMapper.cs
@@ -55,7 +55,7 @@ namespace NuGet.Lucene.Web.Symbols
             sb.AppendFormat("DATETIME={0}" + Environment.NewLine, DateTime.UtcNow);
             sb.AppendLine("SRCSRV: variables ------------------------------------------");
             sb.AppendLine("SRCSRVVERCTRL=http");
-            sb.AppendFormat("SRCSRVTRG={0}/%var4%/%var2%/%var5%",symbolSourceUri);
+            sb.AppendFormat("SRCSRVTRG={0}/%var4%/%var2%/%var5%" + Environment.NewLine,symbolSourceUri);
             sb.AppendLine("SRCSRVCMD=");
             sb.AppendLine("SRCSRV: source files ---------------------------------------");
 


### PR DESCRIPTION
A new line separator was missing after the URL to the source files. This was causing the source server to return a 404 since the URL was including the _SRCSRVCMD=_ string at the end.